### PR TITLE
chore(pre-commit): Bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,15 +24,15 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.16.3
     hooks:
       - id: ruff
   - repo: https://github.com/python-poetry/poetry
-    rev: 2.3.2
+    rev: 2.4.1
     hooks:
       - id: poetry-check
       - id: poetry-install
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v26.3.0
+    rev: v26.8.0
     hooks:
       - id: ansible-lint
         stages:


### PR DESCRIPTION

## Proposed Changes 
 - Update black (26.3.1 -> 26.5.1)
 - Update ruff-pre-commit (v0.15.8 -> v0.16.3)
 - Update poetry (2.3.2 -> 2.4.1)
 - Update ansible-lint.git (v26.3.0 -> v26.8.0)
